### PR TITLE
Properly report class vs instance method

### DIFF
--- a/Symbolicator.mm
+++ b/Symbolicator.mm
@@ -22,7 +22,7 @@ MethodEntry *createMethodEntry(NSUInteger imp, const char *className,const char 
 {
     MethodEntry *entry = (MethodEntry *)malloc(sizeof(MethodEntry));
     entry->imp = imp;
-    entry->name[0] = NO ? '+' : '-';
+    entry->name[0] = isClassMethod ? '+' : '-';
     entry->name[1] = '[';
     strcpy(entry->name+2,className);
     entry->name[strlen(className)+2] = ' ';


### PR DESCRIPTION
It seems like symbolicator would not properly report whether the method is a class or an instance method; this fixes it.
